### PR TITLE
Add lists of DNS and NTP per interface

### DIFF
--- a/src/netconfig.cpp
+++ b/src/netconfig.cpp
@@ -195,9 +195,10 @@ static void cmdDhcpcfg(Dbus& bus, Arguments& args)
     puts(completeMessage);
 }
 
-/** @brief Add/remove DNS server: `dns {add|del} [static] IP` */
+/** @brief Add/remove DNS server: `dns {INTERFACE} {add|del} [static] IP` */
 static void cmdDns(Dbus& bus, Arguments& args)
 {
+    const char* iface = args.asNetInterface();
     const Action action = args.asAction();
 
     const char* nextArg = args.peek();
@@ -216,7 +217,7 @@ static void cmdDns(Dbus& bus, Arguments& args)
     const auto [_, srv] = args.asIpAddress();
     args.expectEnd();
 
-    const std::string object = Dbus::ethToPath(Dbus::defaultEth);
+    const std::string object = Dbus::ethToPath(iface);
 
     printf("%s DNS server %s...\n",
            action == Action::add ? "Adding" : "Removing", srv);
@@ -233,14 +234,15 @@ static void cmdDns(Dbus& bus, Arguments& args)
     puts(completeMessage);
 }
 
-/** @brief Add/remove NTP server: `ntp {add|del} IP` */
+/** @brief Add/remove NTP server: `ntp {INTERFACE} {add|del} IP` */
 static void cmdNtp(Dbus& bus, Arguments& args)
 {
+    const char* iface = args.asNetInterface();
     const Action action = args.asAction();
     const char* srv = args.asText();
     args.expectEnd();
 
-    const std::string object = Dbus::ethToPath(Dbus::defaultEth);
+    const std::string object = Dbus::ethToPath(iface);
 
     printf("%s NTP server %s...\n",
            action == Action::add ? "Adding" : "Removing", srv);
@@ -296,8 +298,8 @@ static const Command commands[] = {
     {"ip", "{INTERFACE} {add|del} IP[/MASK GATEWAY]", "Add or remove static IP address", cmdIp},
     {"dhcp", "{INTERFACE} {enable|disable}", "Enable or disable DHCP client", cmdDhcp},
     {"dhcpcfg", "{enable|disable} {dns|ntp}", "Enable or disable DHCP features", cmdDhcpcfg},
-    {"dns", "{add|del} [static] IP", "Add or remove DNS server", cmdDns},
-    {"ntp", "{add|del} IP", "Add or remove NTP server", cmdNtp},
+    {"dns", "{INTERFACE} {add|del} [static] IP", "Add or remove DNS server", cmdDns},
+    {"ntp", "{INTERFACE} {add|del} IP", "Add or remove NTP server", cmdNtp},
     {"vlan", "{add|del} {INTERFACE} ID", "Add or remove VLAN", cmdVlan},
 };
 // clang-format on

--- a/src/show.cpp
+++ b/src/show.cpp
@@ -25,14 +25,6 @@ void Show::print()
     printProperty("DNS over DHCP", Dbus::dhcpDnsEnabled, dhcpCfg);
     printProperty("NTP over DHCP", Dbus::dhcpNtpEnabled, dhcpCfg);
 
-    // DNS and NTP servers are bound to the default interface
-    puts("DNS and NTP servers list:");
-    const std::string defEth = Dbus::ethToPath(Dbus::defaultEth);
-    const auto cfgDnsNtp = getProperties(defEth.c_str(), Dbus::ethInterface);
-    printProperty("DNS servers", Dbus::ethNameServers, cfgDnsNtp);
-    printProperty("Static DNS servers", Dbus::ethStNameServers, cfgDnsNtp);
-    printProperty("NTP servers", Dbus::ethNtpServers, cfgDnsNtp);
-
     // Network interfaces
     for (const auto& it : netObjects)
     {
@@ -72,6 +64,11 @@ void Show::printInterface(const char* obj)
     }
 
     printProperty("DHCP", Dbus::ethDhcpEnabled, cfgEth);
+
+    const auto cfgDnsNtp = getProperties(obj, Dbus::ethInterface);
+    printProperty("DNS servers", Dbus::ethNameServers, cfgDnsNtp);
+    printProperty("Static DNS servers", Dbus::ethStNameServers, cfgDnsNtp);
+    printProperty("NTP servers", Dbus::ethNtpServers, cfgDnsNtp);
 }
 
 void Show::printProperty(const char* title, const char* name,


### PR DESCRIPTION
This brings personal lists of DNS and NTP servers for each interface
instead of global ones.

Signed-off-by: Alexander Filippov <a.filippov@yadro.com>