### PR TITLE
Fix dhcp settings

### DIFF
--- a/src/netconfig.cpp
+++ b/src/netconfig.cpp
@@ -158,9 +158,23 @@ static void cmdDhcp(Dbus& bus, Arguments& args)
     args.expectEnd();
 
     const std::string object = Dbus::ethToPath(iface);
-    const bool enable = toggle == Toggle::enable;
+    std::string enable;
 
-    printf("%s DHCP client...\n", enable ? "Enable" : "Disable");
+    switch (toggle)
+    {
+        case Toggle::enable:
+            enable =
+                "xyz.openbmc_project.Network.EthernetInterface.DHCPConf.both";
+            break;
+
+        case Toggle::disable:
+            enable =
+                "xyz.openbmc_project.Network.EthernetInterface.DHCPConf.none";
+            break;
+    }
+
+    printf("%s DHCP client...\n",
+           toggle == Toggle::enable ? "Enable" : "Disable");
 
     bus.set(object.c_str(), Dbus::ethInterface, Dbus::ethDhcpEnabled, enable);
 


### PR DESCRIPTION
The API of DHCP settings was changed by the upstream.
This brings a quick fix which keeps a previous behavior with the new API.

In the future we'll implement the whole possible values of this setting.

Signed-off-by: Alexander Filippov <a.filippov@yadro.com>