### PR TITLE
ip add/del: Make the network mask optional

### DIFF
--- a/src/arguments.cpp
+++ b/src/arguments.cpp
@@ -182,9 +182,21 @@ std::tuple<IpVer, std::string, uint8_t> Arguments::asIpAddrMask()
             }
         }
     }
+    else
+    {
+        const std::optional<IpVer> ver = isIpAddress(arg);
+        if (ver.has_value())
+        {
+            constexpr uint8_t ip4Prefix = 24;
+            constexpr uint8_t ip6Prefix = 64;
+
+            return std::make_tuple(ver.value(), arg,
+                                   ver == IpVer::v4 ? ip4Prefix : ip6Prefix);
+        }
+    }
     std::string err = "Invalid argument: ";
     err += arg;
-    err += ", expected IP/PREFIX (e.g. 10.0.0.1/8)";
+    err += ", expected IP[/PREFIX] (e.g. 10.0.0.1/8 or 192.168.1.1)";
     throw std::invalid_argument(err);
 }
 

--- a/test/arguments_test.cpp
+++ b/test/arguments_test.cpp
@@ -134,6 +134,7 @@ TEST(ArgumentsTest, IpAddrMask)
                         const_cast<char*>("127.0.0.1/"),
                         const_cast<char*>("127.0.0/8"),
                         const_cast<char*>("2001:db8:a::123/64"),
+                        const_cast<char*>("2001:db8:a::123"),
                         const_cast<char*>("text"),
                         const_cast<char*>("")};
     const int argsNum = sizeof(testArgs) / sizeof(testArgs[0]);
@@ -143,9 +144,11 @@ TEST(ArgumentsTest, IpAddrMask)
     EXPECT_EQ(args.asIpAddrMask(), std::make_tuple(IpVer::v4, "127.0.0.1", 8));
     ASSERT_THROW(args.asIpAddrMask(), std::invalid_argument);
     ASSERT_THROW(args.asIpAddrMask(), std::invalid_argument);
+    EXPECT_EQ(args.asIpAddrMask(), std::make_tuple(IpVer::v4, "127.0.0.1", 24));
     ASSERT_THROW(args.asIpAddrMask(), std::invalid_argument);
     ASSERT_THROW(args.asIpAddrMask(), std::invalid_argument);
-    ASSERT_THROW(args.asIpAddrMask(), std::invalid_argument);
+    EXPECT_EQ(args.asIpAddrMask(),
+              std::make_tuple(IpVer::v6, "2001:db8:a::123", 64));
     EXPECT_EQ(args.asIpAddrMask(),
               std::make_tuple(IpVer::v6, "2001:db8:a::123", 64));
     ASSERT_THROW(args.asIpAddrMask(), std::invalid_argument);


### PR DESCRIPTION
According the help message the network mask is optional, but in fact it
is strongly required for the adding IP address and occurs an error in
the deleting.

This commit makes it really optional:
 - The add command by default will use 24 for IPv4 and 64 for IPv6.
 - The delete command will ignore the mask.

It is useful for editing the commands from shell history.

Signed-off-by: Alexander Filippov <a.filippov@yadro.com>