### PR TITLE
Improve IP comparison

### DIFF
--- a/src/arguments.hpp
+++ b/src/arguments.hpp
@@ -161,7 +161,7 @@ class Arguments
      *
      * @return argument value: IP version and address
      */
-    std::tuple<IpVer, const char*> asIpAddress();
+    std::tuple<IpVer, std::string> asIpAddress();
 
     /**
      * @brief Get current argument as IP address with prefix length.
@@ -184,13 +184,15 @@ class Arguments
     static bool isNumber(const char* arg);
 
     /**
-     * @brief Check for IP address.
+     * @brief Trying to parse string as an IP address.
      *
-     * @param[in] arg value to check
+     * @param[in] arg value to parse
      *
-     * @return IP version or nullopt if checked value is not a valid IP address
+     * @throw std::invalid_argument if parsing is failed
+     *
+     * @return IP version and string with the IP address in unified format.
      */
-    static std::optional<IpVer> isIpAddress(const char* arg);
+    static std::tuple<IpVer, std::string> parseIpAddress(const char* arg);
 
   private:
     using Args = std::vector<char*>;

--- a/src/netconfig.cpp
+++ b/src/netconfig.cpp
@@ -87,7 +87,7 @@ static void cmdGateway(Dbus& bus, Arguments& args)
     args.expectEnd();
 
     printf("Setting default gateway for IPv%i to %s...\n",
-           static_cast<int>(ver), ip);
+           static_cast<int>(ver), ip.c_str());
 
     const char* property =
         ver == IpVer::v4 ? Dbus::syscfgDefGw4 : Dbus::syscfgDefGw6;
@@ -215,7 +215,7 @@ static void cmdDns(Dbus& bus, Arguments& args)
         const auto [_, srv] = args.asIpAddress();
         servers.emplace_back(srv);
         printf("%s DNS server %s...\n",
-               action == Action::add ? "Adding" : "Removing", srv);
+               action == Action::add ? "Adding" : "Removing", srv.c_str());
     }
     args.expectEnd();
 

--- a/test/arguments_test.cpp
+++ b/test/arguments_test.cpp
@@ -106,6 +106,7 @@ TEST(ArgumentsTest, IpAddress)
         const_cast<char*>("127.0.0,1"),
         const_cast<char*>("127.0.0"),
         const_cast<char*>("127.0.0.1.2"),
+        const_cast<char*>("2001:db8:85a3::8a2e:370:7334"),
         const_cast<char*>("2001:0db8:85a3:0000:0000:8a2e:0370:7334"),
         const_cast<char*>("::"),
         const_cast<char*>("text"),
@@ -120,7 +121,10 @@ TEST(ArgumentsTest, IpAddress)
     ASSERT_THROW(args.asIpAddress(), std::invalid_argument);
     ASSERT_THROW(args.asIpAddress(), std::invalid_argument);
     EXPECT_EQ(args.asIpAddress(), std::make_tuple(IpVer::v6, testArgs[5]));
-    EXPECT_EQ(args.asIpAddress(), std::make_tuple(IpVer::v6, testArgs[6]));
+    // NOTE: Next test checks that zeroed words are truncated.
+    //       So, the same index using in testArgs[] is not a mistype.
+    EXPECT_EQ(args.asIpAddress(), std::make_tuple(IpVer::v6, testArgs[5]));
+    EXPECT_EQ(args.asIpAddress(), std::make_tuple(IpVer::v6, testArgs[7]));
     ASSERT_THROW(args.asIpAddress(), std::invalid_argument);
     ASSERT_THROW(args.asIpAddress(), std::invalid_argument);
 }


### PR DESCRIPTION
IPv6 can be specified in several different formats.
It might include zeroes instead of skipped fields and encode mapped IPv4
as raw bytes.

For example:
  `0:0:0:0:0:ffff:ac11:1b21` -> `::ffff:172.17.27.33`

This commit makes the tool always convert user specified data to the
unified format before operating.

Change-Id: Ib1aed706735fb2c21ef47d845256963247a267bb
Signed-off-by: Alexander Filippov <a.filippov@yadro.com>