### PR TITLE
help: Don't display banner in CLI mode

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright (C) 2020 YADRO
+// Copyright (C) 2020-2021 YADRO
 
 #include "netconfig.hpp"
 #include "version.hpp"
@@ -15,6 +15,15 @@ int main(int argc, char* argv[])
     try
     {
         const char* cmd = args.peek();
+        bool cli_mode = false;
+
+        if (cmd && !strcmp(cmd, "--cli"))
+        {
+            cli_mode = true;
+            ++args;
+            cmd = args.peek();
+        }
+
         if (!cmd || strcmp(cmd, "help") == 0 || strcmp(cmd, "--help") == 0 ||
             strcmp(cmd, "-h") == 0)
         {
@@ -24,12 +33,17 @@ int main(int argc, char* argv[])
             }
             if (!args.peek())
             {
-                printf("OpenBMC network configuration.\n");
-                printf("Copyright (c) 2020 YADRO.\n");
-                printf("Version " VERSION ".\n");
+                if (!cli_mode)
+                {
+                    printf("OpenBMC network configuration tool\n");
+                    printf("Copyright (C) 2020-2021 YADRO\n");
+                    printf("Version " VERSION "\n\n");
+                }
                 printf("Usage: %s COMMAND [OPTION...]\n", app);
+                printf("       %s help COMMAND\n\n", app);
+                printf("COMMANDS:\n");
             }
-            help(args);
+            help(cli_mode, app, args);
         }
         else
         {

--- a/src/netconfig.cpp
+++ b/src/netconfig.cpp
@@ -328,7 +328,7 @@ void execute(Arguments& args)
     throw std::invalid_argument(err);
 }
 
-void help(Arguments& args)
+void help(bool cli_mode, const char* app, Arguments& args)
 {
     const char* helpForCmd = args.peek();
     if (helpForCmd)
@@ -349,7 +349,18 @@ void help(Arguments& args)
             throw std::invalid_argument(err);
         }
         puts(cmdEntry->help);
-        printf("%s %s\n", cmdEntry->name, cmdEntry->fmt ? cmdEntry->fmt : "");
+
+        // Command-specific help should not include the name of the command
+        // in CLI mode as in that mode it will be passed in as part of `app`
+        // and may differ from the actual command being processed, e.g.
+        // CLI command `bmc datetime ntpconfig` equals `netconfig ntp`,
+        // and the help must pretend it's the CLI command.
+        printf("%s ", app);
+        if (!cli_mode)
+        {
+            printf("%s ", cmdEntry->name);
+        }
+        printf("%s\n", cmdEntry->fmt ? cmdEntry->fmt : "");
     }
     else
     {

--- a/src/netconfig.hpp
+++ b/src/netconfig.hpp
@@ -17,6 +17,9 @@ void execute(Arguments& args);
 /**
  * @brief Print usage help.
  *
- * @param[in] args command line arguments
+ * @param[in] cli_mode CLI mode. Don't prepend arguments info with
+ *                     the command name for single-command help.
+ * @param[in] app      application name
+ * @param[in] args     command line arguments
  */
-void help(Arguments& args);
+void help(bool cli_mode, const char *app, Arguments& args);


### PR DESCRIPTION
Allow for use in CLI mode (for use with obmc-yadro-cli):
- Do not display a banner when `--cli` option is given
- Add the application name before command-specific help
- Omit the command name in command specific help in CLI
  mode so that the name of the CLI command could be passed
  in as argv[0]

Signed-off-by: Alexander Amelkin <a.amelkin@yadro.com>