### PR TITLE
Add support for `help` as the first arg of command

### DIFF
--- a/src/arguments.cpp
+++ b/src/arguments.cpp
@@ -46,6 +46,15 @@ const char* Arguments::peek() const
     return current == args.end() ? nullptr : *current;
 }
 
+const char* Arguments::peekNext() const
+{
+    if (peek() && (current + 1) != args.end()) {
+        return *(current + 1);
+    }
+
+    return nullptr;
+}
+
 const char* Arguments::asText()
 {
     const char* arg = peek();

--- a/src/arguments.hpp
+++ b/src/arguments.hpp
@@ -75,6 +75,13 @@ class Arguments
     const char* peek() const;
 
     /**
+     * @brief Peek next argument.
+     *
+     * @return argument text or nullptr if no argument is available
+     */
+    const char* peekNext() const;
+
+    /**
      * @brief Get current argument as pointer to text data.
      *        Argument pointer will be moved to the next entry.
      *

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,6 +6,12 @@
 
 #include <cstring>
 
+bool isHelp(const char* str)
+{
+    return str && (!strcmp(str, "help") || !strcmp(str, "--help") ||
+                   !strcmp(str, "-h"));
+}
+
 /** @brief Application entry point. */
 int main(int argc, char* argv[])
 {
@@ -24,10 +30,12 @@ int main(int argc, char* argv[])
             cmd = args.peek();
         }
 
-        if (!cmd || strcmp(cmd, "help") == 0 || strcmp(cmd, "--help") == 0 ||
-            strcmp(cmd, "-h") == 0)
+        const char* firstArg = args.peekNext();
+        const bool firstArgHelp = isHelp(firstArg); // Save on strcmp calls
+
+        if (!cmd || isHelp(cmd) || firstArgHelp)
         {
-            if (cmd)
+            if (cmd && !firstArgHelp)
             {
                 ++args;
             }


### PR DESCRIPTION
Also support `-h` and `--help`.
This makes netconfig behave more like built-in
commands in obmc-yadro-cli

End-user-impact: It is now possible to call `netconfig <cmd> help`
                 as well as the old way `netconfig help <cmd>`.

Signed-off-by: Alexander Amelkin <a.amelkin@yadro.com>