### PR TITLE
Hide tool from unprivileged user

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -35,5 +35,6 @@ executable(
   dependencies: [
     dependency('sdbusplus'),
   ],
-  install: true
+  install: true,
+  install_dir: get_option('sbindir'),
 )


### PR DESCRIPTION
The unprivileged users cannot call this tool directly.
This commit moves it to the `/usr/sbin` directory.

Signed-off-by: Alexander Filippov <a.filippov@yadro.com>