### PR TITLE
Add --cli-hide-cmd option

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -21,12 +21,18 @@ int main(int argc, char* argv[])
     try
     {
         const char* cmd = args.peek();
-        bool cli_mode = false;
+        CLIMode mode = CLIMode::normalMode;
 
-        if (cmd && !strcmp(cmd, "--cli"))
+        if (cmd && !strncmp(cmd, "--cli", 5))
         {
-            cli_mode = true;
+            mode = CLIMode::cliMode;
             ++args;
+
+            if (!strcmp(cmd, "--cli-hide-cmd"))
+            {
+                mode = CLIMode::cliModeNoCommand;
+            }
+
             cmd = args.peek();
         }
 
@@ -41,7 +47,7 @@ int main(int argc, char* argv[])
             }
             if (!args.peek())
             {
-                if (!cli_mode)
+                if (mode == CLIMode::normalMode)
                 {
                     printf("OpenBMC network configuration tool\n");
                     printf("Copyright (C) 2020-2021 YADRO\n");
@@ -51,7 +57,7 @@ int main(int argc, char* argv[])
                 printf("       %s help COMMAND\n\n", app);
                 printf("COMMANDS:\n");
             }
-            help(cli_mode, app, args);
+            help(mode, app, args);
         }
         else
         {

--- a/src/netconfig.cpp
+++ b/src/netconfig.cpp
@@ -343,7 +343,7 @@ void execute(Arguments& args)
     throw std::invalid_argument(err);
 }
 
-void help(bool cli_mode, const char* app, Arguments& args)
+void help(CLIMode mode, const char* app, Arguments& args)
 {
     const char* helpForCmd = args.peek();
     if (helpForCmd)
@@ -371,7 +371,7 @@ void help(bool cli_mode, const char* app, Arguments& args)
         // CLI command `bmc datetime ntpconfig` equals `netconfig ntp`,
         // and the help must pretend it's the CLI command.
         printf("%s ", app);
-        if (!cli_mode)
+        if (mode != CLIMode::cliModeNoCommand)
         {
             printf("%s ", cmdEntry->name);
         }

--- a/src/netconfig.hpp
+++ b/src/netconfig.hpp
@@ -14,6 +14,12 @@
  */
 void execute(Arguments& args);
 
+enum class CLIMode {
+  normalMode, ///< Normal mode, print the banner and the command name in help
+  cliMode, ///< CLI mode, do not print banner, print command name in help
+  cliModeNoCommand ///< CLI mode, print neither the banner, nor the command name in help
+};
+
 /**
  * @brief Print usage help.
  *
@@ -22,4 +28,4 @@ void execute(Arguments& args);
  * @param[in] app      application name
  * @param[in] args     command line arguments
  */
-void help(bool cli_mode, const char *app, Arguments& args);
+void help(cli_mode mode, const char *app, Arguments& args);


### PR DESCRIPTION
Some commands in obmc-yadro-cli require the command name
to be hidden in the help (e.g. for `bmc ntpconfig help`),
while others require the name to be shown in the help
(e.g. `bmc ifconfig help ntp`).

This commit extends the `--cli` option with another
version, `--cli-hide-cmd`. The former one will only
hide the banner while the latter will hide both the
banner and the command name in the command help.

Signed-off-by: Alexander Amelkin <a.amelkin@yadro.com>