### PR TITLE
Refix c0b47545069ed4a64bf1e1434315657d64ab3c5d

### DIFF
--- a/src/netconfig.hpp
+++ b/src/netconfig.hpp
@@ -28,4 +28,4 @@ enum class CLIMode {
  * @param[in] app      application name
  * @param[in] args     command line arguments
  */
-void help(cli_mode mode, const char *app, Arguments& args);
+void help(CLIMode mode, const char *app, Arguments& args);


### PR DESCRIPTION
Wrong type for mode parameter of help() was committed
by mistake. Fix that.

Signed-off-by: Alexander Amelkin <a.amelkin@yadro.com>