### PR TITLE
Add user-friendly error message and return code.

### DIFF
--- a/src/netconfig.cpp
+++ b/src/netconfig.cpp
@@ -266,6 +266,16 @@ static void cmdNtp(Dbus& bus, Arguments& args)
     puts(completeMessage);
 }
 
+/** @brief Check VLAN ID for IEEE 802.1Q conformance */
+static void checkVlanId(const uint32_t id)
+{
+    if ((id < minVlanId) || (id > maxVlanId))
+    {
+        std::string err = "Invalid VLAN ID. Must be [2 - 4094], see IEEE 802.1Q.";
+        throw std::invalid_argument(err);
+    }
+}
+
 /** @brief Add/remove VLAN: `vlan {add|del} {INTERFACE} ID` */
 static void cmdVlan(Dbus& bus, Arguments& args)
 {
@@ -273,6 +283,8 @@ static void cmdVlan(Dbus& bus, Arguments& args)
     const char* iface = args.asNetInterface();
     const uint32_t id = static_cast<uint32_t>(args.asNumber());
     args.expectEnd();
+
+    checkVlanId(id);
 
     printf("%s VLAN with ID %u...\n",
            action == Action::add ? "Adding" : "Removing", id);
@@ -298,10 +310,7 @@ static void cmdVlan(Dbus& bus, Arguments& args)
         {
             puts("Can't delete a nonexistent interface.");
         }
-        else
-        {
-            puts(e.what());
-        }
+        throw;
     }
 
     puts(completeMessage);

--- a/src/netconfig.hpp
+++ b/src/netconfig.hpp
@@ -29,3 +29,7 @@ enum class CLIMode {
  * @param[in] args     command line arguments
  */
 void help(CLIMode mode, const char *app, Arguments& args);
+
+/** @brief IEEE 802.1Q VLAN ID limits. */
+static constexpr uint32_t minVlanId = 2;
+static constexpr uint32_t maxVlanId = 4094;


### PR DESCRIPTION
Providing an invalid VLAN Id will result in
a user-friendly error message.
Also every error during VLAN creation will now return
a non-zero status code.

Signed-off-by: Kirill Pakhomov <k.pakhomov@yadro.com>