### PR TITLE
Сorrected the regexp for the rightmost domain label

### DIFF
--- a/src/arguments.cpp
+++ b/src/arguments.cpp
@@ -244,10 +244,15 @@ std::string Arguments::asIpOrFQDN()
         "(^"
         // - The length of any single label is limited to 63 octets.
         // - labels must not start or end with hyphens.
+        // According to RFC1123 (section 2.1):
+        // "...a segment of a host domain name is now allowed
+        // to begin with a digit and could legally be entirely numeric".
         // - Total number of labels is limited to 127
         "((?!-)[a-z0-9-]{0,62}[a-z0-9]\\.){0,126}"
-        // Trailing dot is optional
-        "((?!-)[a-z0-9-]{0,62}[a-z0-9]\\.?)"
+        // Trailing dot is optional.
+        // According to RFC1738 (section 3.1):
+        // "The rightmost domain label will never start with a digit".
+        "((?![0-9-])[a-z0-9-]{0,62}[a-z0-9]\\.?)"
         "$)",
         std::regex_constants::icase);
 
@@ -258,7 +263,8 @@ std::string Arguments::asIpOrFQDN()
 
     std::string err = "Invalid argument: ";
     err += arg;
-    err += ", expected IP address or FQDN";
+    err += ", expected IP address or FQDN. ";
+    err += "Please, enter IPv4-addresses in dotted-decimal format.";
     throw std::invalid_argument(err);
 }
 

--- a/test/arguments_test.cpp
+++ b/test/arguments_test.cpp
@@ -163,13 +163,15 @@ TEST(ArgumentsTest, IpOrFQDNPositive)
 {
     char* testArgs[] = {
         const_cast<char*>("127.0.0.1"),
+        const_cast<char*>("::"),
         const_cast<char*>("::1"),
+        const_cast<char*>("2001:db8:85a3::8a2e:370:7334"),
         const_cast<char*>("a.com"),
         const_cast<char*>("foo-bar.com"),
         const_cast<char*>("1.2.3.4.com"),
         const_cast<char*>("xn--d1abbgf6aiiy.xn--p1ai"), // президент.рф
         const_cast<char*>("text"),
-        const_cast<char*>("123"),
+        const_cast<char*>("a123"),
         const_cast<char*>("a."),
         const_cast<char*>("a"),
         const_cast<char*>("foo-bar"),
@@ -202,6 +204,8 @@ TEST(ArgumentsTest, IpOrFQDNPositive)
     EXPECT_EQ(args.asIpOrFQDN(), testArgs[11]);
     EXPECT_EQ(args.asIpOrFQDN(), testArgs[12]);
     EXPECT_EQ(args.asIpOrFQDN(), testArgs[13]);
+    EXPECT_EQ(args.asIpOrFQDN(), testArgs[14]);
+    EXPECT_EQ(args.asIpOrFQDN(), testArgs[15]);
 }
 
 TEST(ArgumentsTest, IpOrFQDNNegative)
@@ -215,6 +219,9 @@ TEST(ArgumentsTest, IpOrFQDNNegative)
         const_cast<char*>(".ru"),
         const_cast<char*>(".xn--p1ai"),
         const_cast<char*>("."),
+        const_cast<char*>("123"),
+        const_cast<char*>("123a"),
+        const_cast<char*>("2001:db8:85a3:1a2b:2234:2223:8a2e:370:7334"),
         const_cast<char*>("-foo-bar-.com"),
         const_cast<char*>("-foo-bar.com"),
         const_cast<char*>("foo-bar-.com"),
@@ -234,6 +241,9 @@ TEST(ArgumentsTest, IpOrFQDNNegative)
 
     Arguments args(argsNum, testArgs);
 
+    ASSERT_THROW(args.asIpOrFQDN(), std::invalid_argument);
+    ASSERT_THROW(args.asIpOrFQDN(), std::invalid_argument);
+    ASSERT_THROW(args.asIpOrFQDN(), std::invalid_argument);
     ASSERT_THROW(args.asIpOrFQDN(), std::invalid_argument);
     ASSERT_THROW(args.asIpOrFQDN(), std::invalid_argument);
     ASSERT_THROW(args.asIpOrFQDN(), std::invalid_argument);


### PR DESCRIPTION
The existing expression allows the user to specify a name
beginning with a digit, which contradicts RFC1738 (sec. 3.1):
"The rightmost domain label will never start with a digit".

This commit fixes that bug.

Signed-off-by: Vladimir Kuznetsov <v.kuznetsov@yadro.com>