### PR TITLE
Deleting VLAN interfaces during network reset

### DIFF
--- a/src/netconfig.cpp
+++ b/src/netconfig.cpp
@@ -51,6 +51,21 @@ static void cmdReset(Dbus& bus, Arguments& args)
 
     puts("Reset network configuration...");
     bus.call(Dbus::objectRoot, Dbus::resetInterface, Dbus::resetMethod);
+
+    std::set<std::string> vlan_ifaces;
+    Show(bus).getVLANIfaces(vlan_ifaces);
+    for(const auto& it : vlan_ifaces)
+    {
+        try
+        {
+            bus.call(it.c_str(), Dbus::deleteInterface, Dbus::deleteMethod);
+        }
+        catch(const std::exception& e)
+        {
+            puts("Can't delete a nonexistent interface");
+        }
+    }
+
     puts(completeMessage);
 }
 

--- a/src/show.cpp
+++ b/src/show.cpp
@@ -35,6 +35,21 @@ void Show::print()
     }
 }
 
+void Show::getVLANIfaces(std::set<std::string>& vlanIfaces)
+{
+    for (const auto& it : netObjects)
+    {
+        if (it.second.find(Dbus::ethInterface) != it.second.end())
+        {
+            const auto cfgVlan = getProperties(static_cast<std::string>(it.first).c_str(), Dbus::vlanInterface);
+            if (!cfgVlan.empty())
+            {
+                vlanIfaces.insert(static_cast<std::string>(it.first));
+            }
+        }
+    }
+}
+
 void Show::printInterface(const char* obj)
 {
     const auto cfgEth = getProperties(obj, Dbus::ethInterface);

--- a/src/show.hpp
+++ b/src/show.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "dbus.hpp"
+#include <set>
 
 /**
  * @class Show
@@ -23,6 +24,12 @@ class Show
      * @brief Print current network configuration.
      */
     void print();
+
+    /**
+     * @brief Parses array of D-Bus network configuration objects
+     * and get all VLAN interfaces
+     */
+    void getVLANIfaces(std::set<std::string>&);
 
   private:
     /**


### PR DESCRIPTION
Currently the VLAN interfaces aren't deleted
during a factory reset.
This commit fixes this bug.

Signed-off-by: Vladimir Kuznetsov <v.kuznetsov@yadro.com>