### PR TITLE
Add 'bmc syslog' commands

### DIFF
--- a/src/arguments.hpp
+++ b/src/arguments.hpp
@@ -38,6 +38,9 @@ enum class IpVer
     v6 = 6
 };
 
+/** @brief Default remote syslog server port */
+static constexpr uint16_t syslogDefPort = 514;
+
 /**
  * @class Arguments
  * @brief Arguments parser.
@@ -185,12 +188,47 @@ class Arguments
      * @brief Get current argument as IP address or hostname.
      *        Argument pointer will be moved to the next entry.
      *
+     * @param[in] param - optional param when parsing 'bmc syslog set' command
+     * args
+     *
      * @throw std::invalid_argument if there are no more arguments to handle
      *                              or argument has invalid format
      *
      * @return IP address in unified format or hostname
      */
-    std::string asIpOrFQDN();
+    std::string
+        asIpOrFQDN(const std::optional<std::string>& param = std::nullopt);
+
+    /**
+     * @brief Parse an argument of the form 'ADDR:PORT' where address can be
+     * IPv4, IPv6, FQDN, PORT is a 16 bit positive integer. The ':PORT' part is
+     * optional. If current argument exists, argument pointer will be moved to
+     * the next entry.
+     *
+     * @return string with the address and port number
+     */
+    std::tuple<std::string, unsigned short> parseAddrAndPort();
+
+    /**
+     * @brief Set address and default port.
+     *
+     * @param[in] str - string with address
+     *
+     * @return string with the address and default port number
+     */
+    std::tuple<std::string, unsigned short>
+        setDefaultPort(const std::string& str);
+
+    /**
+     * @brief Parse port number from string arg
+     *
+     * @param[in] str - string with port number value
+     *
+     * @throw std::invalid_argument if argument has invalid format
+     *
+     * @return port number
+     */
+    unsigned short parsePortFromString(const std::string& str);
 
     /**
      * @brief Check for unsigned numeric format.

--- a/src/dbus.cpp
+++ b/src/dbus.cpp
@@ -8,10 +8,12 @@
 Dbus::Dbus() : bus(sdbusplus::bus::new_default())
 {}
 
-void Dbus::append(const char* object, const char* interface, const char* name,
+void Dbus::append(const char* service, const char* object,
+                  const char* interface, const char* name,
                   const std::vector<std::string>& values)
 {
-    auto array = get<std::vector<std::string>>(object, interface, name);
+    auto array =
+        get<std::vector<std::string>>(service, object, interface, name);
     bool needUpdate = false;
 
     for (const auto& value : values)
@@ -29,13 +31,15 @@ void Dbus::append(const char* object, const char* interface, const char* name,
         throw std::invalid_argument("No new values specified");
     }
 
-    set(object, interface, name, array);
+    set(service, object, interface, name, array);
 }
 
-void Dbus::remove(const char* object, const char* interface, const char* name,
+void Dbus::remove(const char* service, const char* object,
+                  const char* interface, const char* name,
                   const std::vector<std::string>& values)
 {
-    auto array = get<std::vector<std::string>>(object, interface, name);
+    auto array =
+        get<std::vector<std::string>>(service, object, interface, name);
     bool needUpdate = false;
 
     for (const auto& value : values)
@@ -53,7 +57,7 @@ void Dbus::remove(const char* object, const char* interface, const char* name,
         throw std::invalid_argument("No values to remove found");
     }
 
-    set(object, interface, name, array);
+    set(service, object, interface, name, array);
 }
 
 std::vector<Dbus::IpAddress> Dbus::getAddresses(const char* ethObject)
@@ -64,7 +68,7 @@ std::vector<Dbus::IpAddress> Dbus::getAddresses(const char* ethObject)
     pathPrefix += "/ip";
 
     Dbus::ManagedObject objects;
-    call(objectRoot, objmgrInterface, objmgrGet).read(objects);
+    call(networkService, objectRoot, objmgrInterface, objmgrGet).read(objects);
 
     for (const auto& it : objects)
     {

--- a/src/netconfig.hpp
+++ b/src/netconfig.hpp
@@ -8,11 +8,12 @@
 /**
  * @brief Execute the configuration command.
  *
+ * @param[in] app  application name
  * @param[in] args command line arguments
  *
  * @throw std::exception in case of errors
  */
-void execute(Arguments& args);
+void execute(const char* app, Arguments& args);
 
 enum class CLIMode {
   normalMode, ///< Normal mode, print the banner and the command name in help
@@ -33,3 +34,11 @@ void help(CLIMode mode, const char *app, Arguments& args);
 /** @brief IEEE 802.1Q VLAN ID limits. */
 static constexpr uint32_t minVlanId = 2;
 static constexpr uint32_t maxVlanId = 4094;
+
+static constexpr const char* netCnfg = "netconfig";
+static constexpr const char* ifcfg = "ifconfig";
+static constexpr const char* sslg = "syslog";
+static constexpr const char* cliIfconfig = "bmc ifconfig";
+static constexpr const char* rootIfconfig = "netconfig ifconfig";
+static constexpr const char* cliSyslog = "bmc syslog";
+static constexpr const char* rootSyslog = "netconfig syslog";

--- a/src/show.cpp
+++ b/src/show.cpp
@@ -5,7 +5,8 @@
 
 Show::Show(Dbus& bus) : bus(bus)
 {
-    bus.call(Dbus::objectRoot, Dbus::objmgrInterface, Dbus::objmgrGet)
+    bus.call(Dbus::networkService, Dbus::objectRoot, Dbus::objmgrInterface,
+             Dbus::objmgrGet)
         .read(netObjects);
 }
 

--- a/test/arguments_test.cpp
+++ b/test/arguments_test.cpp
@@ -260,3 +260,87 @@ TEST(ArgumentsTest, IpOrFQDNNegative)
     ASSERT_THROW(args.asIpOrFQDN(), std::invalid_argument);
     ASSERT_THROW(args.asIpOrFQDN(), std::invalid_argument);
 }
+
+TEST(ArgumentsTest, AddrAndPortPositive)
+{
+    char* testArgs[] = {
+        const_cast<char*>("127.0.0.1"),
+        const_cast<char*>("127.0.0.1:12345"),
+        const_cast<char*>("3001:db8:11a3:9d7:1f34:8a2e:17a0:765d"),
+        const_cast<char*>("[3001:db8:11a3:9d7:1f34:8a2e:17a0:765d]:65534"),
+        const_cast<char*>("3001::765d"),
+        const_cast<char*>("[3001::765d]:65534"),
+        const_cast<char*>("a.com"),
+        const_cast<char*>("a.com:234"),
+        const_cast<char*>("text"),
+        const_cast<char*>("text:56"),
+    };
+
+    const int argsNum = sizeof(testArgs) / sizeof(testArgs[0]);
+
+    Arguments args(argsNum, testArgs);
+
+    EXPECT_EQ(args.parseAddrAndPort(), std::make_tuple("127.0.0.1", 514));
+    args.asText();
+    EXPECT_EQ(args.parseAddrAndPort(), std::make_tuple("127.0.0.1", 12345));
+    args.asText();
+    EXPECT_EQ(args.parseAddrAndPort(),
+              std::make_tuple("3001:db8:11a3:9d7:1f34:8a2e:17a0:765d", 514));
+    args.asText();
+    EXPECT_EQ(args.parseAddrAndPort(),
+              std::make_tuple("3001:db8:11a3:9d7:1f34:8a2e:17a0:765d", 65534));
+    args.asText();
+    EXPECT_EQ(args.parseAddrAndPort(), std::make_tuple("3001::765d", 514));
+    args.asText();
+    EXPECT_EQ(args.parseAddrAndPort(), std::make_tuple("3001::765d", 65534));
+    args.asText();
+    EXPECT_EQ(args.parseAddrAndPort(), std::make_tuple("a.com", 514));
+    args.asText();
+    EXPECT_EQ(args.parseAddrAndPort(), std::make_tuple("a.com", 234));
+    args.asText();
+    EXPECT_EQ(args.parseAddrAndPort(), std::make_tuple("text", 514));
+    args.asText();
+    EXPECT_EQ(args.parseAddrAndPort(), std::make_tuple("text", 56));
+    args.asText();
+}
+
+TEST(ArgumentsTest, AddrAndPortNegative)
+{
+    char* testArgs[] = {
+        const_cast<char*>("127.0.0.1.1"),
+        const_cast<char*>("256.0.0.1"),
+        const_cast<char*>("127.0.0.1:65536"),
+        const_cast<char*>("127.0.0.1:w"),
+        const_cast<char*>("3001:db8:11a3:9d7:1f34:8a2e:17a0:765d:123"),
+        const_cast<char*>("[3001:db8:11a3:9d7:1f34:8a2e:17a0:765d]:-15"),
+        const_cast<char*>("[3001::765d]:db8"),
+        const_cast<char*>("a.1"),
+        const_cast<char*>("a.com:1000000"),
+        const_cast<char*>("[text]:56"),
+    };
+
+    const int argsNum = sizeof(testArgs) / sizeof(testArgs[0]);
+
+    Arguments args(argsNum, testArgs);
+
+    ASSERT_THROW(args.parseAddrAndPort(), std::invalid_argument);
+    args.asText();
+    ASSERT_THROW(args.parseAddrAndPort(), std::invalid_argument);
+    args.asText();
+    ASSERT_THROW(args.parseAddrAndPort(), std::invalid_argument);
+    args.asText();
+    ASSERT_THROW(args.parseAddrAndPort(), std::invalid_argument);
+    args.asText();
+    ASSERT_THROW(args.parseAddrAndPort(), std::invalid_argument);
+    args.asText();
+    ASSERT_THROW(args.parseAddrAndPort(), std::invalid_argument);
+    args.asText();
+    ASSERT_THROW(args.parseAddrAndPort(), std::invalid_argument);
+    args.asText();
+    ASSERT_THROW(args.parseAddrAndPort(), std::invalid_argument);
+    args.asText();
+    ASSERT_THROW(args.parseAddrAndPort(), std::invalid_argument);
+    args.asText();
+    ASSERT_THROW(args.parseAddrAndPort(), std::invalid_argument);
+    args.asText();
+}


### PR DESCRIPTION
The argument parsing and handling of the 'bmc syslog'
commands (set, reset, show) is moved from obmc-yadro-cli.
Added the syslog remote server address check.

End-User-Impact: The address can be IPv4, IPv6 or FQDN

Signed-off-by: Vladimir Kuznetsov <v.kuznetsov@yadro.com>