### PR TITLE
Add 'bmc syslog' commands

### DIFF
--- a/src/arguments.hpp
+++ b/src/arguments.hpp
@@ -38,6 +38,9 @@ enum class IpVer
     v6 = 6
 };
 
+/** @brief Default remote syslog server port */
+static constexpr uint16_t syslogDefPort = 514;
+
 /**
  * @class Arguments
  * @brief Arguments parser.
@@ -185,12 +188,47 @@ class Arguments
      * @brief Get current argument as IP address or hostname.
      *        Argument pointer will be moved to the next entry.
      *
+     * @param[in] param - optional param when parsing 'bmc syslog set' command
+     * args
+     *
      * @throw std::invalid_argument if there are no more arguments to handle
      *                              or argument has invalid format
      *
      * @return IP address in unified format or hostname
      */
-    std::string asIpOrFQDN();
+    std::string
+        asIpOrFQDN(const std::optional<std::string>& param = std::nullopt);
+
+    /**
+     * @brief Parse an argument of the form 'ADDR:PORT' where address can be
+     * IPv4, IPv6, FQDN, PORT is a 16 bit positive integer. The ':PORT' part is
+     * optional. If current argument exists, argument pointer will be moved to
+     * the next entry.
+     *
+     * @return string with the address and port number
+     */
+    std::tuple<std::string, unsigned short> parseAddrAndPort();
+
+    /**
+     * @brief Set address and default port.
+     *
+     * @param[in] str - string with address
+     *
+     * @return string with the address and default port number
+     */
+    std::tuple<std::string, unsigned short>
+        setDefaultPort(const std::string& str);
+
+    /**
+     * @brief Parse port number from string arg
+     *
+     * @param[in] str - string with port number value
+     *
+     * @throw std::invalid_argument if argument has invalid format
+     *
+     * @return port number
+     */
+    unsigned short parsePortFromString(const std::string& str);
 
     /**
      * @brief Check for unsigned numeric format.

--- a/src/dbus.cpp
+++ b/src/dbus.cpp
@@ -8,10 +8,12 @@
 Dbus::Dbus() : bus(sdbusplus::bus::new_default())
 {}
 
-void Dbus::append(const char* object, const char* interface, const char* name,
+void Dbus::append(const char* service, const char* object,
+                  const char* interface, const char* name,
                   const std::vector<std::string>& values)
 {
-    auto array = get<std::vector<std::string>>(object, interface, name);
+    auto array =
+        get<std::vector<std::string>>(service, object, interface, name);
     bool needUpdate = false;
 
     for (const auto& value : values)
@@ -29,13 +31,15 @@ void Dbus::append(const char* object, const char* interface, const char* name,
         throw std::invalid_argument("No new values specified");
     }
 
-    set(object, interface, name, array);
+    set(service, object, interface, name, array);
 }
 
-void Dbus::remove(const char* object, const char* interface, const char* name,
+void Dbus::remove(const char* service, const char* object,
+                  const char* interface, const char* name,
                   const std::vector<std::string>& values)
 {
-    auto array = get<std::vector<std::string>>(object, interface, name);
+    auto array =
+        get<std::vector<std::string>>(service, object, interface, name);
     bool needUpdate = false;
 
     for (const auto& value : values)
@@ -53,7 +57,7 @@ void Dbus::remove(const char* object, const char* interface, const char* name,
         throw std::invalid_argument("No values to remove found");
     }
 
-    set(object, interface, name, array);
+    set(service, object, interface, name, array);
 }
 
 std::vector<Dbus::IpAddress> Dbus::getAddresses(const char* ethObject)
@@ -64,7 +68,7 @@ std::vector<Dbus::IpAddress> Dbus::getAddresses(const char* ethObject)
     pathPrefix += "/ip";
 
     Dbus::ManagedObject objects;
-    call(objectRoot, objmgrInterface, objmgrGet).read(objects);
+    call(networkService, objectRoot, objmgrInterface, objmgrGet).read(objects);
 
     for (const auto& it : objects)
     {

--- a/src/netconfig.cpp
+++ b/src/netconfig.cpp
@@ -50,7 +50,8 @@ static void cmdReset(Dbus& bus, Arguments& args)
     args.expectEnd();
 
     puts("Reset network configuration...");
-    bus.call(Dbus::objectRoot, Dbus::resetInterface, Dbus::resetMethod);
+    bus.call(Dbus::networkService, Dbus::objectRoot, Dbus::resetInterface,
+             Dbus::resetMethod);
     puts(completeMessage);
 }
 
@@ -64,7 +65,8 @@ static void cmdMac(Dbus& bus, Arguments& args)
     const std::string object = Dbus::ethToPath(iface);
 
     printf("Set new MAC address %s...\n", mac);
-    bus.set(object.c_str(), Dbus::macInterface, Dbus::macSet, mac);
+    bus.set(Dbus::networkService, object.c_str(), Dbus::macInterface,
+            Dbus::macSet, mac);
     puts(completeMessage);
 }
 
@@ -75,12 +77,12 @@ static void cmdHostname(Dbus& bus, Arguments& args)
     args.expectEnd();
 
     printf("Set new host name %s...\n", name.c_str());
-    bus.set(Dbus::objectConfig, Dbus::syscfgInterface, Dbus::syscfgHostname,
-            name);
+    bus.set(Dbus::networkService, Dbus::objectConfig, Dbus::syscfgInterface,
+            Dbus::syscfgHostname, name);
     puts(completeMessage);
 }
 
-/** @brief Set default gateway: `getway IP` */
+/** @brief Set default gateway: `gateway IP` */
 static void cmdGateway(Dbus& bus, Arguments& args)
 {
     const auto [ver, ip] = args.asIpAddress();
@@ -92,7 +94,8 @@ static void cmdGateway(Dbus& bus, Arguments& args)
     const char* property =
         ver == IpVer::v4 ? Dbus::syscfgDefGw4 : Dbus::syscfgDefGw6;
 
-    bus.set(Dbus::objectConfig, Dbus::syscfgInterface, property, ip);
+    bus.set(Dbus::networkService, Dbus::objectConfig, Dbus::syscfgInterface,
+            property, ip);
 
     puts(completeMessage);
 }
@@ -112,8 +115,8 @@ static void cmdIp(Dbus& bus, Arguments& args)
         const char* ipInterface =
             ipVer == IpVer::v4 ? Dbus::ip4Interface : Dbus::ip6Interface;
 
-        bus.call(object.c_str(), Dbus::ipCreateInterface, Dbus::ipCreateMethod,
-                 ipInterface, ip, mask, "");
+        bus.call(Dbus::networkService, object.c_str(), Dbus::ipCreateInterface,
+                 Dbus::ipCreateMethod, ipInterface, ip, mask, "");
 
         printf("Request for setting %s/%d on %s has been sent\n", ip.c_str(),
                mask, iface);
@@ -126,8 +129,8 @@ static void cmdIp(Dbus& bus, Arguments& args)
         {
             if (it.address == ip)
             {
-                bus.call(it.object.c_str(), Dbus::deleteInterface,
-                         Dbus::deleteMethod);
+                bus.call(Dbus::networkService, it.object.c_str(),
+                         Dbus::deleteInterface, Dbus::deleteMethod);
                 handled = true;
                 break;
             }
@@ -170,7 +173,8 @@ static void cmdDhcp(Dbus& bus, Arguments& args)
     printf("%s DHCP client...\n",
            toggle == Toggle::enable ? "Enable" : "Disable");
 
-    bus.set(object.c_str(), Dbus::ethInterface, Dbus::ethDhcpEnabled, enable);
+    bus.set(Dbus::networkService, object.c_str(), Dbus::ethInterface,
+            Dbus::ethDhcpEnabled, enable);
 
     puts(completeMessage);
 }
@@ -190,14 +194,14 @@ static void cmdDhcpcfg(Dbus& bus, Arguments& args)
     if (strcmp(feature, featureDns) == 0)
     {
         printf("%s DNS over DHCP...\n", enable ? "Enable" : "Disable");
-        bus.set(Dbus::objectDhcp, Dbus::dhcpInterface, Dbus::dhcpDnsEnabled,
-                enable);
+        bus.set(Dbus::networkService, Dbus::objectDhcp, Dbus::dhcpInterface,
+                Dbus::dhcpDnsEnabled, enable);
     }
     else
     {
         printf("%s NTP over DHCP...\n", enable ? "Enable" : "Disable");
-        bus.set(Dbus::objectDhcp, Dbus::dhcpInterface, Dbus::dhcpNtpEnabled,
-                enable);
+        bus.set(Dbus::networkService, Dbus::objectDhcp, Dbus::dhcpInterface,
+                Dbus::dhcpNtpEnabled, enable);
     }
 
     puts(completeMessage);
@@ -222,13 +226,13 @@ static void cmdDns(Dbus& bus, Arguments& args)
     const std::string object = Dbus::ethToPath(iface);
     if (action == Action::add)
     {
-        bus.append(object.c_str(), Dbus::ethInterface, Dbus::ethStNameServers,
-                   servers);
+        bus.append(Dbus::networkService, object.c_str(), Dbus::ethInterface,
+                   Dbus::ethStNameServers, servers);
     }
     else
     {
-        bus.remove(object.c_str(), Dbus::ethInterface, Dbus::ethStNameServers,
-                   servers);
+        bus.remove(Dbus::networkService, object.c_str(), Dbus::ethInterface,
+                   Dbus::ethStNameServers, servers);
     }
 
     puts(completeMessage);
@@ -254,13 +258,13 @@ static void cmdNtp(Dbus& bus, Arguments& args)
 
     if (action == Action::add)
     {
-        bus.append(object.c_str(), Dbus::ethInterface, Dbus::ethNtpServers,
-                   servers);
+        bus.append(Dbus::networkService, object.c_str(), Dbus::ethInterface,
+                   Dbus::ethNtpServers, servers);
     }
     else
     {
-        bus.remove(object.c_str(), Dbus::ethInterface, Dbus::ethNtpServers,
-                   servers);
+        bus.remove(Dbus::networkService, object.c_str(), Dbus::ethInterface,
+                   Dbus::ethNtpServers, servers);
     }
 
     puts(completeMessage);
@@ -293,14 +297,16 @@ static void cmdVlan(Dbus& bus, Arguments& args)
     {
         if (action == Action::add)
         {
-            bus.call(Dbus::objectRoot, Dbus::vlanCreateInterface,
-                    Dbus::vlanCreateMethod, iface, id);
+            bus.call(Dbus::networkService, Dbus::objectRoot,
+                     Dbus::vlanCreateInterface, Dbus::vlanCreateMethod, iface,
+                     id);
         }
         else
         {
             const std::string object =
                 Dbus::ethToPath(iface) + '_' + std::to_string(id);
-            bus.call(object.c_str(), Dbus::deleteInterface, Dbus::deleteMethod);
+            bus.call(Dbus::networkService, object.c_str(),
+                     Dbus::deleteInterface, Dbus::deleteMethod);
         }
     }
     catch(const std::exception& e)
@@ -316,9 +322,62 @@ static void cmdVlan(Dbus& bus, Arguments& args)
     puts(completeMessage);
 }
 
+/** @brief Configure remote syslog server: `set ADDR[:PORT]` */
+static void cmdSyslogSet(Dbus& bus, Arguments& args)
+{
+    const auto [addr, port] = args.parseAddrAndPort();
+    if (args.peek() != nullptr)
+    {
+        args.asText();
+        args.expectEnd();
+    }
+
+    printf("Set remote syslog server %s:%u...\n", addr.c_str(), port);
+    bus.set(Dbus::syslogService, Dbus::objectSyslog, Dbus::syslogInterface,
+            Dbus::syslogAddr, addr);
+    bus.set(Dbus::syslogService, Dbus::objectSyslog, Dbus::syslogInterface,
+            Dbus::syslogPort, port);
+    puts(completeMessage);
+}
+
+/** @brief Reset syslog settings: `reset` */
+static void cmdSyslogReset(Dbus& bus, Arguments& args)
+{
+    std::string addr{""};
+    unsigned short port{0};
+    args.expectEnd();
+    bus.set(Dbus::syslogService, Dbus::objectSyslog, Dbus::syslogInterface,
+            Dbus::syslogAddr, addr);
+    bus.set(Dbus::syslogService, Dbus::objectSyslog, Dbus::syslogInterface,
+            Dbus::syslogPort, port);
+    puts(completeMessage);
+}
+
+/** @brief Show the configured remote syslog server: `show` */
+static void cmdSyslogShow(Dbus& bus, Arguments& args)
+{
+    args.expectEnd();
+    std::string addr =
+        bus.get<std::string>(Dbus::syslogService, Dbus::objectSyslog,
+                             Dbus::syslogInterface, Dbus::syslogAddr);
+    unsigned short port =
+        bus.get<unsigned short>(Dbus::syslogService, Dbus::objectSyslog,
+                                Dbus::syslogInterface, Dbus::syslogPort);
+
+    printf("Remote syslog server: ");
+    if (addr == "" || port == 0)
+    {
+        printf("(none)\n");
+    }
+    else if (addr != "")
+    {
+        printf("%s:%u (tcp)\n", addr.c_str(), port);
+    }
+}
+
 // clang-format off
 /** @brief List of command descriptions. */
-static const Command commands[] = {
+static const Command ifconfigCommands[] = {
     {"show", nullptr, "Show current configuration", cmdShow},
     {"reset", nullptr, "Reset configuration to factory defaults", cmdReset},
     {"mac", "{INTERFACE} MAC", "Set MAC address", cmdMac},
@@ -331,18 +390,53 @@ static const Command commands[] = {
     {"ntp", "{INTERFACE} {add|del} ADDR [ADDR..]", "Add or remove NTP server", cmdNtp},
     {"vlan", "{add|del} {INTERFACE} ID", "Add or remove VLAN", cmdVlan},
 };
+
+static const Command syslogCommands[] = {
+    {"set", "ADDR[:PORT]", "Configure remote syslog server (Address and an optional TCP port (default is 514))", cmdSyslogSet},
+    {"reset", nullptr, "Reset syslog settings. Alias for the syslog set command without arguments.", cmdSyslogReset},
+    {"show", nullptr, "Show the configured remote syslog server", cmdSyslogShow},
+};
 // clang-format on
 
-void execute(Arguments& args)
+static std::tuple<const Command*, unsigned int>
+    getCommandsArray(const char* app)
+{
+    const Command* cmdArr;
+    unsigned int arrSize;
+
+    if (!strcmp(app, cliIfconfig) || !strcmp(app, cliDatetime) ||
+        !strcmp(app, rootIfconfig))
+    {
+        cmdArr = ifconfigCommands;
+        arrSize = sizeof(ifconfigCommands) / sizeof(Command);
+    }
+    else if (!strcmp(app, cliSyslog) || !strcmp(app, rootSyslog))
+    {
+        cmdArr = syslogCommands;
+        arrSize = sizeof(syslogCommands) / sizeof(Command);
+    }
+    else
+    {
+        std::string err = "Invalid argument: ";
+        err += app;
+        throw std::invalid_argument(err);
+    }
+
+    return std::make_tuple(cmdArr, arrSize);
+}
+
+void execute(const char* app, Arguments& args)
 {
     const char* cmdName = args.asText();
+    std::tuple<const Command*, unsigned short> cmds = getCommandsArray(app);
 
-    for (const auto& cmd : commands)
+    for (const auto* it = std::get<0>(cmds);
+         it != std::get<0>(cmds) + std::get<1>(cmds); ++it)
     {
-        if (strcmp(cmdName, cmd.name) == 0)
+        if (strcmp(cmdName, it->name) == 0)
         {
             Dbus bus;
-            cmd.fn(bus, args);
+            it->fn(bus, args);
             return;
         }
     }
@@ -355,14 +449,16 @@ void execute(Arguments& args)
 void help(CLIMode mode, const char* app, Arguments& args)
 {
     const char* helpForCmd = args.peek();
+    std::tuple<const Command*, unsigned short> cmds = getCommandsArray(app);
     if (helpForCmd)
     {
         const Command* cmdEntry = nullptr;
-        for (const auto& cmd : commands)
+        for (const auto* it = std::get<0>(cmds);
+             it != std::get<0>(cmds) + std::get<1>(cmds); ++it)
         {
-            if (strcmp(helpForCmd, cmd.name) == 0)
+            if (strcmp(helpForCmd, it->name) == 0)
             {
-                cmdEntry = &cmd;
+                cmdEntry = it;
                 break;
             }
         }
@@ -388,13 +484,14 @@ void help(CLIMode mode, const char* app, Arguments& args)
     }
     else
     {
-        for (const auto& cmd : commands)
+        for (const auto* it = std::get<0>(cmds);
+             it != std::get<0>(cmds) + std::get<1>(cmds); ++it)
         {
-            printf("  %-10s %s\n", cmd.name, cmd.help);
-            if (cmd.fmt)
+            printf("  %-10s %s\n", it->name, it->help);
+            if (it->fmt)
             {
-                printf("  %-10s Command format: %s %s\n", "", cmd.name,
-                       cmd.fmt);
+                printf("  %-10s Command format: %s %s\n", "", it->name,
+                       it->fmt);
             }
             printf("\n");
         }

--- a/src/netconfig.hpp
+++ b/src/netconfig.hpp
@@ -8,11 +8,12 @@
 /**
  * @brief Execute the configuration command.
  *
+ * @param[in] app  application name
  * @param[in] args command line arguments
  *
  * @throw std::exception in case of errors
  */
-void execute(Arguments& args);
+void execute(const char* app, Arguments& args);
 
 enum class CLIMode {
   normalMode, ///< Normal mode, print the banner and the command name in help
@@ -33,3 +34,12 @@ void help(CLIMode mode, const char *app, Arguments& args);
 /** @brief IEEE 802.1Q VLAN ID limits. */
 static constexpr uint32_t minVlanId = 2;
 static constexpr uint32_t maxVlanId = 4094;
+
+static constexpr const char* netCnfg = "netconfig";
+static constexpr const char* ifcfg = "ifconfig";
+static constexpr const char* sslg = "syslog";
+static constexpr const char* cliIfconfig = "bmc ifconfig";
+static constexpr const char* rootIfconfig = "netconfig ifconfig";
+static constexpr const char* cliSyslog = "bmc syslog";
+static constexpr const char* rootSyslog = "netconfig syslog";
+static constexpr const char* cliDatetime = "bmc datetime ntpconfig";

--- a/src/show.cpp
+++ b/src/show.cpp
@@ -5,7 +5,8 @@
 
 Show::Show(Dbus& bus) : bus(bus)
 {
-    bus.call(Dbus::objectRoot, Dbus::objmgrInterface, Dbus::objmgrGet)
+    bus.call(Dbus::networkService, Dbus::objectRoot, Dbus::objmgrInterface,
+             Dbus::objmgrGet)
         .read(netObjects);
 }
 

--- a/test/arguments_test.cpp
+++ b/test/arguments_test.cpp
@@ -260,3 +260,87 @@ TEST(ArgumentsTest, IpOrFQDNNegative)
     ASSERT_THROW(args.asIpOrFQDN(), std::invalid_argument);
     ASSERT_THROW(args.asIpOrFQDN(), std::invalid_argument);
 }
+
+TEST(ArgumentsTest, AddrAndPortPositive)
+{
+    char* testArgs[] = {
+        const_cast<char*>("127.0.0.1"),
+        const_cast<char*>("127.0.0.1:12345"),
+        const_cast<char*>("3001:db8:11a3:9d7:1f34:8a2e:17a0:765d"),
+        const_cast<char*>("[3001:db8:11a3:9d7:1f34:8a2e:17a0:765d]:65534"),
+        const_cast<char*>("3001::765d"),
+        const_cast<char*>("[3001::765d]:65534"),
+        const_cast<char*>("a.com"),
+        const_cast<char*>("a.com:234"),
+        const_cast<char*>("text"),
+        const_cast<char*>("text:56"),
+    };
+
+    const int argsNum = sizeof(testArgs) / sizeof(testArgs[0]);
+
+    Arguments args(argsNum, testArgs);
+
+    EXPECT_EQ(args.parseAddrAndPort(), std::make_tuple("127.0.0.1", 514));
+    args.asText();
+    EXPECT_EQ(args.parseAddrAndPort(), std::make_tuple("127.0.0.1", 12345));
+    args.asText();
+    EXPECT_EQ(args.parseAddrAndPort(),
+              std::make_tuple("3001:db8:11a3:9d7:1f34:8a2e:17a0:765d", 514));
+    args.asText();
+    EXPECT_EQ(args.parseAddrAndPort(),
+              std::make_tuple("3001:db8:11a3:9d7:1f34:8a2e:17a0:765d", 65534));
+    args.asText();
+    EXPECT_EQ(args.parseAddrAndPort(), std::make_tuple("3001::765d", 514));
+    args.asText();
+    EXPECT_EQ(args.parseAddrAndPort(), std::make_tuple("3001::765d", 65534));
+    args.asText();
+    EXPECT_EQ(args.parseAddrAndPort(), std::make_tuple("a.com", 514));
+    args.asText();
+    EXPECT_EQ(args.parseAddrAndPort(), std::make_tuple("a.com", 234));
+    args.asText();
+    EXPECT_EQ(args.parseAddrAndPort(), std::make_tuple("text", 514));
+    args.asText();
+    EXPECT_EQ(args.parseAddrAndPort(), std::make_tuple("text", 56));
+    args.asText();
+}
+
+TEST(ArgumentsTest, AddrAndPortNegative)
+{
+    char* testArgs[] = {
+        const_cast<char*>("127.0.0.1.1"),
+        const_cast<char*>("256.0.0.1"),
+        const_cast<char*>("127.0.0.1:65536"),
+        const_cast<char*>("127.0.0.1:w"),
+        const_cast<char*>("3001:db8:11a3:9d7:1f34:8a2e:17a0:765d:123"),
+        const_cast<char*>("[3001:db8:11a3:9d7:1f34:8a2e:17a0:765d]:-15"),
+        const_cast<char*>("[3001::765d]:db8"),
+        const_cast<char*>("a.1"),
+        const_cast<char*>("a.com:1000000"),
+        const_cast<char*>("[text]:56"),
+    };
+
+    const int argsNum = sizeof(testArgs) / sizeof(testArgs[0]);
+
+    Arguments args(argsNum, testArgs);
+
+    ASSERT_THROW(args.parseAddrAndPort(), std::invalid_argument);
+    args.asText();
+    ASSERT_THROW(args.parseAddrAndPort(), std::invalid_argument);
+    args.asText();
+    ASSERT_THROW(args.parseAddrAndPort(), std::invalid_argument);
+    args.asText();
+    ASSERT_THROW(args.parseAddrAndPort(), std::invalid_argument);
+    args.asText();
+    ASSERT_THROW(args.parseAddrAndPort(), std::invalid_argument);
+    args.asText();
+    ASSERT_THROW(args.parseAddrAndPort(), std::invalid_argument);
+    args.asText();
+    ASSERT_THROW(args.parseAddrAndPort(), std::invalid_argument);
+    args.asText();
+    ASSERT_THROW(args.parseAddrAndPort(), std::invalid_argument);
+    args.asText();
+    ASSERT_THROW(args.parseAddrAndPort(), std::invalid_argument);
+    args.asText();
+    ASSERT_THROW(args.parseAddrAndPort(), std::invalid_argument);
+    args.asText();
+}


### PR DESCRIPTION
The argument parsing and handling of the 'bmc syslog' commands (set, reset, show) is moved from obmc-yadro-cli. Added the syslog remote server address check.

End-User-Impact: The address can be IPv4, IPv6 or FQDN

Signed-off-by: Vladimir Kuznetsov <v.kuznetsov@yadro.com>