### PR TITLE
Update 'bmc datetime ntpconfig' processing

### DIFF
--- a/src/netconfig.cpp
+++ b/src/netconfig.cpp
@@ -82,7 +82,7 @@ static void cmdHostname(Dbus& bus, Arguments& args)
     puts(completeMessage);
 }
 
-/** @brief Set default gateway: `getway IP` */
+/** @brief Set default gateway: `gateway IP` */
 static void cmdGateway(Dbus& bus, Arguments& args)
 {
     const auto [ver, ip] = args.asIpAddress();

--- a/src/netconfig.cpp
+++ b/src/netconfig.cpp
@@ -401,7 +401,8 @@ static std::tuple<const Command*, unsigned int>
     const Command* cmdArr;
     unsigned int arrSize;
 
-    if (!strcmp(app, cliIfconfig) || !strcmp(app, rootIfconfig))
+    if (!strcmp(app, cliIfconfig) || !strcmp(app, cliDatetime) ||
+        !strcmp(app, rootIfconfig))
     {
         cmdArr = ifconfigCommands;
         arrSize = sizeof(ifconfigCommands) / sizeof(Command);

--- a/src/netconfig.cpp
+++ b/src/netconfig.cpp
@@ -322,6 +322,7 @@ static void cmdVlan(Dbus& bus, Arguments& args)
     puts(completeMessage);
 }
 
+/** @brief Configure remote syslog server: `set ADDR[:PORT]` */
 static void cmdSyslogSet(Dbus& bus, Arguments& args)
 {
     const auto [addr, port] = args.parseAddrAndPort();
@@ -339,6 +340,7 @@ static void cmdSyslogSet(Dbus& bus, Arguments& args)
     puts(completeMessage);
 }
 
+/** @brief Reset syslog settings: `reset` */
 static void cmdSyslogReset(Dbus& bus, Arguments& args)
 {
     std::string addr{""};
@@ -351,6 +353,7 @@ static void cmdSyslogReset(Dbus& bus, Arguments& args)
     puts(completeMessage);
 }
 
+/** @brief Show the configured remote syslog server: `show` */
 static void cmdSyslogShow(Dbus& bus, Arguments& args)
 {
     args.expectEnd();

--- a/src/netconfig.hpp
+++ b/src/netconfig.hpp
@@ -42,3 +42,4 @@ static constexpr const char* cliIfconfig = "bmc ifconfig";
 static constexpr const char* rootIfconfig = "netconfig ifconfig";
 static constexpr const char* cliSyslog = "bmc syslog";
 static constexpr const char* rootSyslog = "netconfig syslog";
+static constexpr const char* cliDatetime = "bmc datetime ntpconfig";


### PR DESCRIPTION
After adding 'bmc syslog' commands to netconfig the 'bmc datetime ntpconfig' command doesn't work correctly ("Invalid argument" message is printed).

This commit fixed that bug.

Signed-off-by: Vladimir Kuznetsov <v.kuznetsov@yadro.com>