### PR TITLE
vegman-rx20g2: add 'shport' command

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -17,6 +17,7 @@ version = vcs_tag(command: [ 'git', 'describe', '--always', '--dirty', '--long' 
 
 conf = configuration_data()
 conf.set_quoted('DEFAULT_NETIFACE', get_option('default-netiface'))
+conf.set('SWITCHABLE_ETH1_PORT', get_option('switchable-eth1-port'))
 configure_file(output: 'config.hpp', configuration: conf)
 
 build_tests = get_option('tests')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -7,3 +7,7 @@ option('default-netiface', type: 'string',
 option('tests',
        type: 'feature',
        description: 'Build tests')
+
+option('switchable-eth1-port',
+       type: 'boolean', value: false,
+       description: 'Add for eth1 port switch feauture')

--- a/src/arguments.cpp
+++ b/src/arguments.cpp
@@ -222,6 +222,17 @@ std::tuple<IpVer, std::string, uint8_t> Arguments::asIpAddrMask()
     throw std::invalid_argument(err);
 }
 
+#ifdef SWITCHABLE_ETH1_PORT
+bool Arguments::asEthSrc(const std::optional<std::string>& param)
+{
+    const char* BMC = "BMC";
+    const char* Host = "Host";
+
+    const char* arg = asOneOf({BMC, Host});
+    return strcmp(arg, BMC) == 0 ? true : false;
+}
+#endif // SWITCHABLE_ETH1_PORT
+
 std::string Arguments::asIpOrFQDN(const std::optional<std::string>& param)
 {
     const char* arg;

--- a/src/arguments.hpp
+++ b/src/arguments.hpp
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include "config.hpp"
+
 #include <optional>
 #include <string>
 #include <tuple>
@@ -198,6 +200,21 @@ class Arguments
      */
     std::string
         asIpOrFQDN(const std::optional<std::string>& param = std::nullopt);
+
+    /**
+     * @brief Get current argument as a shared ethernet port source
+     *
+     * @param[in] param - param when parsing 'bmc ifconfig shport' command
+     * args
+     *
+     * @throw std::invalid_argument if there are no more arguments to handle
+     *                              or argument has invalid format
+     *
+     * @return bool value true=BMC, false=Host
+     */
+#ifdef SWITCHABLE_ETH1_PORT
+    bool asEthSrc(const std::optional<std::string>& param = std::nullopt);
+#endif // SWITCHABLE_ETH1_PORT
 
     /**
      * @brief Parse an argument of the form 'ADDR:PORT' where address can be

--- a/src/dbus.hpp
+++ b/src/dbus.hpp
@@ -19,6 +19,9 @@ class Dbus
 
     // Network service name
     static constexpr const char* networkService = "xyz.openbmc_project.Network";
+    // Settings service name
+    static constexpr const char* settingsService =
+        "xyz.openbmc_project.Settings";
     // Syslog service name
     static constexpr const char* syslogService =
         "xyz.openbmc_project.Syslog.Config";
@@ -31,6 +34,10 @@ class Dbus
         "/xyz/openbmc_project/network/config/dhcp";
     static constexpr const char* objectSyslog =
         "/xyz/openbmc_project/logging/config/remote";
+#ifdef SWITCHABLE_ETH1_PORT
+    static constexpr const char* objectSharedPort =
+        "/xyz/openbmc_project/network/shared_port";
+#endif // SWITCHABLE_ETH1_PORT
 
     // System Configuration interface, its methods and properties
     static constexpr const char* syscfgInterface =
@@ -53,6 +60,11 @@ class Dbus
     // Ethernet interface, its methods and properties
     static constexpr const char* ethInterface =
         "xyz.openbmc_project.Network.EthernetInterface";
+#ifdef SWITCHABLE_ETH1_PORT
+    static constexpr const char* sharedPortInterface =
+        "xyz.openbmc_project.Network.SharedPort";
+    static constexpr const char* sharedPortSource = "Source";
+#endif // SWITCHABLE_ETH1_PORT
     static constexpr const char* ethName = "InterfaceName";
     static constexpr const char* ethDhcpEnabled = "DHCPEnabled";
     static constexpr const char* ethNtpServers = "NTPServers";

--- a/src/netconfig.cpp
+++ b/src/netconfig.cpp
@@ -322,6 +322,20 @@ static void cmdVlan(Dbus& bus, Arguments& args)
     puts(completeMessage);
 }
 
+/** @brief Set source for eth1 shared interface(BMC/Host*/
+#ifdef SWITCHABLE_ETH1_PORT
+static void cmdSharedIfaceSrc(Dbus& bus, Arguments& args)
+{
+    bool arg = args.asEthSrc();
+    args.expectEnd();
+
+    printf("Set shared port eth1 source as %s...\n", arg ? "BMC" : "Host");
+    bus.set(Dbus::settingsService, Dbus::objectSharedPort,
+            Dbus::sharedPortInterface, Dbus::sharedPortSource, arg);
+    puts(completeMessage);
+}
+#endif // SWITCHABLE_ETH1_PORT
+
 /** @brief Configure remote syslog server: `set ADDR[:PORT]` */
 static void cmdSyslogSet(Dbus& bus, Arguments& args)
 {
@@ -388,6 +402,9 @@ static const Command ifconfigCommands[] = {
     {"dhcpcfg", "{enable|disable} {dns|ntp}", "Enable or disable DHCP features", cmdDhcpcfg},
     {"dns", "{INTERFACE} {add|del} IP [IP..]", "Add or remove DNS server", cmdDns},
     {"ntp", "{INTERFACE} {add|del} ADDR [ADDR..]", "Add or remove NTP server", cmdNtp},
+#ifdef SWITCHABLE_ETH1_PORT
+    {"shport", "{BMC|Host}", "Set source for eth1 shared interface(BMC/Host)", cmdSharedIfaceSrc},
+#endif // SWITCHABLE_ETH1_PORT
     {"vlan", "{add|del} {INTERFACE} ID", "Add or remove VLAN", cmdVlan},
 };
 

--- a/test/meson.build
+++ b/test/meson.build
@@ -11,6 +11,6 @@ test(
     dependencies: [
       dependency('gtest', main: true, disabler: true, required: build_tests),
     ],
-    include_directories: '../src',
+    include_directories: ['..', '../src'],
   )
 )


### PR DESCRIPTION
Add 'shport' command to switch shared ethernet port source between 'BMC' and 'Host'

Signed-off-by: Georgii Matyukhin g.matyukhin@yadro.com